### PR TITLE
Docker image for inference

### DIFF
--- a/DAGAN_v1/docker/Dockerfile.cpu
+++ b/DAGAN_v1/docker/Dockerfile.cpu
@@ -1,0 +1,25 @@
+FROM python:3.8-buster
+
+RUN apt-get update && apt-get install -y git wget
+
+COPY scripts/download_dagan_model.sh /code/scripts/download_dagan_model.sh
+WORKDIR /code
+RUN mkdir -p checkpoints
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_cityscapes
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_ade
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_facades
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_celeba
+
+RUN git clone https://github.com/vacancy/Synchronized-BatchNorm-PyTorch /tmp/Synchronized-BatchNorm-PyTorch
+
+RUN pip install \
+    dominate>=2.6.0 \
+    dill==0.3.3 \
+    scikit-image==0.18.1 \
+    torch==1.7.0 \
+    torchvision==0.8.0
+
+COPY . /code
+RUN mv /tmp/Synchronized-BatchNorm-PyTorch/sync_batchnorm models/networks/sync_batchnorm
+
+ENTRYPOINT ["python", "test.py", "--checkpoints_dir", "./checkpoints", "--batchSize", "1", "--gpu", "-1"]

--- a/DAGAN_v1/docker/Dockerfile.gpu
+++ b/DAGAN_v1/docker/Dockerfile.gpu
@@ -1,0 +1,23 @@
+FROM pytorch/pytorch:1.7.0-cuda11.0-cudnn8-devel
+
+RUN apt-get update && apt-get install -y git wget
+
+COPY scripts/download_dagan_model.sh /code/scripts/download_dagan_model.sh
+WORKDIR /code
+RUN mkdir -p checkpoints
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_cityscapes
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_ade
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_facades
+RUN sh scripts/download_dagan_model.sh GauGAN_DAGAN_celeba
+
+RUN git clone https://github.com/vacancy/Synchronized-BatchNorm-PyTorch /tmp/Synchronized-BatchNorm-PyTorch
+
+RUN pip install \
+    dominate>=2.6.0 \
+    dill==0.3.3 \
+    scikit-image==0.18.1
+
+COPY . /code
+RUN mv /tmp/Synchronized-BatchNorm-PyTorch/sync_batchnorm models/networks/sync_batchnorm
+
+ENTRYPOINT ["python", "test.py", "--checkpoints_dir", "./checkpoints", "--batchSize", "1"]

--- a/DAGAN_v1/docker/build-and-push.sh
+++ b/DAGAN_v1/docker/build-and-push.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -eux
+
+# Run this script from the repo's root folder, pointing to ade20k for testing:
+#
+# $ ./docker/build-and-push.sh <ADEChallengeData2016_dir>
+
+ade20k_dir="$(realpath "$1")"
+
+# 1. Build Docker images for CPU and GPU
+
+image="us-docker.pkg.dev/replicate/ha0tang/dagan_v1"
+cpu_tag="$image:cpu"
+gpu_tag="$image:gpu"
+docker build -f docker/Dockerfile.cpu --tag "$cpu_tag" .
+docker build -f docker/Dockerfile.gpu --tag "$gpu_tag" .
+
+# 2. Test the Docker images on ade20k data
+
+test_output_folder=/tmp/test-dagan/output
+
+time docker run -it \
+       -v "$ade20k_dir":/data \
+       -v $test_output_folder/cpu:/results \
+       $cpu_tag \
+       --name GauGAN_DAGAN_ade_pretrained \
+       --dataset_mode ade20k \
+       --dataroot /data \
+       --results_dir /results \
+       --how_many 3
+
+[ -f $test_output_folder/cpu/GauGAN_DAGAN_ade_pretrained/test_latest/images/synthesized_image/ADE_val_00000001.png ] || exit 1
+[ -f $test_output_folder/cpu/GauGAN_DAGAN_ade_pretrained/test_latest/index.html ] || exit 1
+
+time docker run --gpus all -it \
+       -v "$ade20k_dir":/data \
+       -v $test_output_folder/gpu:/results \
+       $gpu_tag \
+       --gpu_ids 0 \
+       --name GauGAN_DAGAN_ade_pretrained \
+       --dataset_mode ade20k \
+       --dataroot /data \
+       --results_dir /results \
+       --how_many 3
+
+[ -f $test_output_folder/gpu/GauGAN_DAGAN_ade_pretrained/test_latest/images/synthesized_image/ADE_val_00000001.png ] || exit 1
+[ -f $test_output_folder/gpu/GauGAN_DAGAN_ade_pretrained/test_latest/index.html ] || exit 1
+
+sudo rm -rf "$test_output_folder"
+
+# 3. Push images
+
+docker push $cpu_tag
+docker push $gpu_tag

--- a/DAGAN_v1/models/networks/generator.py
+++ b/DAGAN_v1/models/networks/generator.py
@@ -100,8 +100,8 @@ class SPADEGenerator(BaseNetwork):
         self.conv_img = nn.Conv2d(final_nc, 3, 3, padding=1)
         self.conv_64 = nn.Conv2d(128, 64, 3, padding=1)
         self.up = nn.Upsample(scale_factor=2)
-        
-        self.channelAtt = ChannelAttention(128,64)
+
+        self.cab = ChannelAttention(128,64)
         self.spatialAtt = SpatialAttention()
 
     def compute_latent_vector_size(self, opt):
@@ -161,8 +161,8 @@ class SPADEGenerator(BaseNetwork):
         if self.opt.num_upsampling_layers == 'most':
             x = self.up(x)
             x = self.up_4(x, seg)
-        
-        x_channel = self.channelAtt([x_tmp,x])
+
+        x_channel = self.cab([x_tmp,x])
         x_spatial = self.spatialAtt(x)
         x = x_channel + x_spatial
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ sh datasets/download_dagan_dataset.sh [dataset]
 where `[dataset]` can be one of `facades`, `deepfashion`, `celeba`, `cityscapes`, `ade20k`, or `coco_stuff`.
 
 ## Generating Images Using Pretrained Model
+
+Pretrained DAGAN models can be run using the Docker image hosted on the Replicate registry: https://beta.replicate.ai/Ha0Tang/DAGAN_v1. Below are instructions for how to run the model without Docker:
+
 1. Download the pretrained models using the following script,
 ```
 sh scripts/download_dagan_model.sh GauGAN_DAGAN_[dataset]


### PR DESCRIPTION
This pull request includes a Dockerfile that packages DAGAN in a reproducible Docker image. I've pushed the image to the Replicate Docker registry and included a link in the README.

I noticed that the pre-trained models failed to load due to the name of the channel attention layer having been renamed from `cab`, so I had to rename it back to `cab`.

We are working to make Replicate a registry of machine learning models that can be easily reproduced. With Docker the models can be run "forever", without having to worry about missing dependencies. The website design is still a work in progress, so it might look a little rough around the edges.